### PR TITLE
Fix migrations in news and categories

### DIFF
--- a/migrations/20220915172329-create-new.js
+++ b/migrations/20220915172329-create-new.js
@@ -21,7 +21,7 @@ module.exports = {
       categorieId: {
         type: Sequelize.INTEGER,
         references: {
-          model: 'Categorie',
+          model: 'Categories',
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/migrations/20220915231847-create-activities.js
+++ b/migrations/20220915231847-create-activities.js
@@ -9,15 +9,15 @@ module.exports = {
         type: Sequelize.INTEGER,
       },
       name: {
-        type: dataTypes.STRING,
+        type: Sequelize.STRING,
         allowNull: false,
       },
       content: {
-        type: dataTypes.TEXT,
+        type: Sequelize.TEXT,
         allowNull: false,
       },
       image: {
-        type: dataTypes.STRING,
+        type: Sequelize.STRING,
       },
       createdAt: {
         allowNull: false,

--- a/models/categories.js
+++ b/models/categories.js
@@ -1,11 +1,11 @@
 'use strict';
 const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
-  class Categories extends Model {
+  class Category extends Model {
     static associate(models) {
     }
   }
-  Categories.init(
+  Category.init(
     {
       name: DataTypes.STRING,
       description: DataTypes.STRING,
@@ -13,10 +13,10 @@ module.exports = (sequelize, DataTypes) => {
     },
     {
       sequelize,
-      modelName: 'Categories',
+      modelName: 'Category',
       paranoid: true,
       timestamps: true
     }
   );
-  return Categories;
+  return Category;
 };

--- a/models/new.js
+++ b/models/new.js
@@ -11,7 +11,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      New.belongsTo(models.Categorie);
+      New.belongsTo(models.Category);
     }
   };
   New.init({

--- a/seeders/20220915174948-create-news.js
+++ b/seeders/20220915174948-create-news.js
@@ -8,12 +8,18 @@ module.exports = {
         content: 'Content for a new with title 1',
         Image: 'https://is2-ssl.mzstatic.com/image/thumb/Purple112/v4/8b/a3/e9/8ba3e910-a240-549d-302c-7dacba2923d2/AppIcon-0-0-1x_U007emarketing-0-0-0-7-0-0-sRGB-0-0-0-GLES2_U002c0-512MB-85-220-0-0.png/1200x630wa.png',
         categorieId: 1,
+        deletedAt: new Date,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
       {
         name: 'Title 2 Example',
         content: 'Content for a new with title 2',
         Image: 'https://previews.123rf.com/images/alhovik/alhovik1709/alhovik170900028/86470277-antecedentes-de-las-noticias-de-%C3%BAltima-hora-world-global-tv-news-banner-design.jpg',
         categorieId: 1,
+        deletedAt: new Date,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     ]
 


### PR DESCRIPTION
Se arreglaron errores que no permitían el correcto funcionamiento de la aplicación.

- Seeder de create-news.js
- Model de Category
- Model de New
- Migration de create-new.js