### PR TITLE
se agrego field deleteAt a la migracion de activities

### DIFF
--- a/migrations/20220915231847-create-activities.js
+++ b/migrations/20220915231847-create-activities.js
@@ -27,6 +27,9 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE,
       },
+      deletedAt: {
+        type: Sequelize.DATE
+      },
     });
   },
   down: async (queryInterface, Sequelize) => {


### PR DESCRIPTION
- Se agrego campo deletedAt a la migración de activities porque al intentar buscar en la base datos arroja el error _"unknown column 'deletedAt' in 'field list"_ ya que no lo encontraba en la tabla 