### PR TITLE
Ot 63 add slides to public endpoint

### DIFF
--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,15 +1,21 @@
 const { Organization } = require('../models/');
+const SlidesDao = require('../dao/slide');
 
 class OrganizationController {
   static async findOrganization(req, res) {
     try {
       const response = await Organization.findOne({
         where: { name: 'Big Org' },
-        attributes: ['name', 'image', 'phone', 'address'],
+        attributes: ['id', 'name', 'image', 'phone', 'address'],
+      });
+      const slides = await SlidesDao.findSlidebyOrganization({
+        where: { organizationId: response.id },
+        exclude: ['createdAt', 'updatedAt', 'deletedAt'],
+        order: ['order', 'ASC'],
       });
       response === null
         ? res.status(404).json({ msg: 'Could not find information' })
-        : res.status(200).json(response);
+        : res.status(200).json({ response, slides });
     } catch (error) {
       return error;
     }

--- a/dao/slide.js
+++ b/dao/slide.js
@@ -21,7 +21,6 @@ class SlidesDap {
   }
   static async findSlidebyOrganization({ where, exclude = [], order = [] }) {
     try {
-      console.log(where)
       const SlideData = await Slide.findAll({
         where: where,
         attributes: { exclude: exclude },

--- a/dao/slide.js
+++ b/dao/slide.js
@@ -19,6 +19,19 @@ class SlidesDap {
       throw new Error(error);
     }
   }
+  static async findSlidebyOrganization({ where, exclude = [], order = [] }) {
+    try {
+      console.log(where)
+      const SlideData = await Slide.findAll({
+        where: where,
+        attributes: { exclude: exclude },
+        order: [order]
+      });
+      return SlideData;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
 }
 
 module.exports = SlidesDap;


### PR DESCRIPTION
Description

AS user
I WANT to see Slides when I enter the page
TO be more informed about them

Criteria of acceptance:

In the public data endpoint of the Organization, the list of Slides ordered by the "order" field must be added.

The Slides will be those belonging to the Organization, based on the organization_id field that should correspond to the Organization that is being returned

![image](https://user-images.githubusercontent.com/82429592/193062671-32ef899f-5503-4cf1-8288-3ac83d9b262e.png)
