### PR TITLE
Ot 80 create migration comments model

### DIFF
--- a/controllers/commentsController.js
+++ b/controllers/commentsController.js
@@ -1,0 +1,7 @@
+const { Comments } = require('../models');
+
+class CommentsControllers {
+
+}
+
+module.exports = CommentsControllers;

--- a/migrations/20221001124913-create-comment.js
+++ b/migrations/20221001124913-create-comment.js
@@ -26,6 +26,9 @@ module.exports = {
               key: 'id',
             },
       },
+      deletedAt: {
+        type: Sequelize.DATE
+      },      
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE

--- a/migrations/20221001124913-create-comment.js
+++ b/migrations/20221001124913-create-comment.js
@@ -1,0 +1,42 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Comments', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id',
+        },
+      },
+      body: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      post_id: {
+            type: Sequelize.INTEGER,
+            references: {
+              model: 'News',
+              key: 'id',
+            },
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('Comments');
+  }
+};

--- a/models/comment.js
+++ b/models/comment.js
@@ -1,0 +1,28 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Comment extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+      Comment.belongsTo(models.User);
+      Comment.belongsTo(models.New);
+    }
+  }
+  Comment.init(
+    {
+      body: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'Comment',
+      paranoid: true,
+      timestamps: true,
+    }
+  );
+  return Comment;
+};

--- a/models/comment.js
+++ b/models/comment.js
@@ -9,8 +9,9 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      Comment.belongsTo(models.User);
-      Comment.belongsTo(models.New);
+      Comment.belongsTo(models.User, {foreignKey:'user_id'});
+      Comment.belongsTo(models.New,  {foreignKey: 'post_id'});
+
     }
   }
   Comment.init(

--- a/seeders/20221005130405-create-comments.js
+++ b/seeders/20221005130405-create-comments.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Comments', [
+      {
+        user_id : 1,
+        body:'Comentario 01',
+        post_id: 1,
+        createdAt: new Date,
+        updatedAt: new Date
+      },
+      {
+        user_id : 1,
+        body:'Comentario 02',
+        post_id: 2,
+        createdAt: new Date,
+        updatedAt: new Date
+      },
+      {
+        user_id : 2,
+        body:'Comentario 03',
+        post_id: 1,
+        createdAt: new Date,
+        updatedAt: new Date
+      },
+
+      {
+        user_id : 2,
+        body:'Comentario 04',
+        post_id: 2,
+        createdAt: new Date,
+        updatedAt: new Date
+      }], {});
+  },
+  down: async (queryInterface, Sequelize) => {
+      await queryInterface.bulkDelete('Comments', null, {});
+  }
+};


### PR DESCRIPTION
PR : Crear migración y modelo de Comentarios
Resumen :
. Se creó la migración y modelación de la tabla "comments"
. Se agregarón los campos :  "body" y dos claves foraneas "user_id" y "post_id"

Evidencia :
![Table Comments](https://user-images.githubusercontent.com/87533958/193864556-3faf6c8a-0b05-4132-b3d6-68f345eeaaf6.JPG)
