### PR TITLE
activities tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "dev": "nodemon ./bin/www",
-    "db:reset": "npx sequelize-cli db:drop && npx sequelize-cli db:create && npx sequelize-cli db:migrate && npx sequelize-cli db:seed:all"
+    "db:reset": "npx sequelize-cli db:drop && npx sequelize-cli db:create && npx sequelize-cli db:migrate && npx sequelize-cli db:seed:all",
+    "test": "mocha test"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.7.0",
@@ -27,8 +28,16 @@
     "swagger-ui-express": "^4.5.0"
   },
   "devDependencies": {
+    "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "chai-http": "^4.3.0",
+    "mocha": "^10.0.0",
     "nodemon": "^2.0.20",
     "prettier": "^2.7.1",
-    "sequelize-cli": "^6.2.0"
+    "rewire": "^6.0.0",
+    "sequelize-cli": "^6.2.0",
+    "sinon": "^14.0.1",
+    "sinon-chai": "^3.7.0",
+    "supertest": "^6.3.0"
   }
 }

--- a/test/activities.js
+++ b/test/activities.js
@@ -1,0 +1,131 @@
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const rewire = require('rewire');
+const request = require('supertest');
+const { Activities } = require('../models');
+const RoleMiddleware = require('../middlewares/verify-role');
+const sandbox = sinon.createSandbox();
+
+describe('activities', () => {
+  beforeEach(() => {
+    fakeAuth = (req, res, next) => {
+      return next();
+    };
+    authStub = sandbox.stub(RoleMiddleware, 'isAdminRole').callsFake(fakeAuth);
+    app = rewire('../app');
+  });
+
+  afterEach(() => {
+    app = rewire('../app');
+    sandbox.restore();
+  });
+
+  context('POST /activities', () => {
+    it('Post a activity with error', (done) => {
+      request(app)
+        .post('/activities')
+        .send({
+          name: 'activity test8585',
+          content: 'content test2343',
+          image: '',
+        })
+        .expect(400)
+        .end((err, response) => {
+          expect(response.body.errors.errors[0])
+            .to.have.property('msg')
+            .to.equal('Image has to be a image URL');
+          expect(response.body.errors.errors[1])
+            .to.have.property('msg')
+            .to.equal('Image is required');
+          done(err);
+        });
+    });
+    it('Post a activity successfully', (done) => {
+      sandbox.stub(Activities, 'create').resolves({
+        name: 'activity test8585',
+        content: 'content test2343',
+        image:
+          'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+      });
+      request(app)
+        .post('/activities')
+        .send({
+          name: 'activity test8585',
+          content: 'content test2343',
+          image:
+            'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        })
+        .expect(201)
+        .end((err, response) => {
+          expect(response.body)
+            .to.have.property('msg')
+            .to.equal('activity created successfully');
+          expect(response.body.activity)
+            .to.have.property('name')
+            .to.equal('activity test8585');
+          expect(response.body.activity)
+            .to.have.property('content')
+            .to.equal('content test2343');
+          expect(response.body.activity)
+            .to.have.property('image')
+            .to.equal(
+              'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1'
+            );
+          done(err);
+        });
+    });
+  });
+  context('PUT /activities/:id', () => {
+    it('Put a activity with error', (done) => {
+      request(app)
+        .put('/activities/1')
+        .send({
+          name: 1234,
+          content: true,
+          image:
+            'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        })
+        .expect(400)
+        .end((err, response) => {
+          expect(response.body.errors.errors[0])
+            .to.have.property('msg')
+            .to.equal('Name has to be a string');
+          expect(response.body.errors.errors[1])
+            .to.have.property('msg')
+            .to.equal('Content has to be a image URL');
+          done(err);
+        });
+    });
+    it('Put a activity successfully', (done) => {
+      sandbox.stub(Activities, 'update').resolves([1]);
+      request(app)
+        .put('/activities/1')
+        .send({
+          name: 'activity test8585',
+          content: 'content test2343',
+          image:
+            'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+        })
+        .expect(200)
+        .end((err, response) => {
+          expect(response.body.activities)
+            .to.have.property('name')
+            .to.equal('activity test8585');
+          expect(response.body.activities)
+            .to.have.property('content')
+            .to.equal('content test2343');
+          expect(response.body.activities)
+            .to.have.property('image')
+            .to.equal(
+              'https://images.pexels.com/photos/6646945/pexels-photo-6646945.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1'
+            );
+          done(err);
+        });
+    });
+  });
+});


### PR DESCRIPTION
Description

AS a developer
I WANT to have tests of the /activities endpoints
TO ensure the integrity and operation of the project

Criteria of acceptance:
Test the correct response scenario, and error scenarios, such as non-existent ids, validations, permissions, etc. The file must be created inside the /test folder, with the same name as the endpoint. The test created as a demonstration can be used as a basis.

![image](https://user-images.githubusercontent.com/82429592/195946307-bf5ee6b5-db6e-4fc6-be0a-0d1051ad75a4.png)
